### PR TITLE
fix: observer panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Usage of ./bin/listener:
   -alsologtostderr
         log to standard error as well as files (no effect when -logtostderr=true)
   -dsn string
-        database conneciton string (default "postgres://bestchains:Passw0rd!@127.0.0.1:5432/bc-explorer?sslmode=disable")
+        database connection string (default "postgres://bestchains:Passw0rd!@127.0.0.1:5432/bc-explorer?sslmode=disable")
   -injector string
         used to initialize injector (default "pg")
   -log_backtrace_at value
@@ -97,7 +97,7 @@ Usage of ./bin/viewer:
   -db string
         which database to use, default is pg(postgresql) (default "pg")
   -dsn string
-        database conneciton string (default "postgres://bestchains:Passw0rd!@127.0.0.1:5432/bc-explorer?sslmode=disable")
+        database connection string (default "postgres://bestchains:Passw0rd!@127.0.0.1:5432/bc-explorer?sslmode=disable")
   -log_backtrace_at value
         when logging hits line file:N, emit a stack trace
   -log_dir string

--- a/cmd/listener/main.go
+++ b/cmd/listener/main.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	injector = flag.String("injector", "pg", "used to initialize injector")
-	dsn      = flag.String("dsn", "postgres://bestchains:Passw0rd!@127.0.0.1:5432/bc-explorer?sslmode=disable", "database conneciton string")
+	dsn      = flag.String("dsn", "postgres://bestchains:Passw0rd!@127.0.0.1:5432/bc-explorer?sslmode=disable", "database connection string")
 	addr     = flag.String("addr", ":9999", "used to listen and serve http requests")
 )
 

--- a/cmd/viewer/main.go
+++ b/cmd/viewer/main.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	db   = flag.String("db", "pg", "which database to use, default is pg(postgresql)")
-	dsn  = flag.String("dsn", "postgres://bestchains:Passw0rd!@127.0.0.1:5432/bc-explorer?sslmode=disable", "database conneciton string")
+	dsn  = flag.String("dsn", "postgres://bestchains:Passw0rd!@127.0.0.1:5432/bc-explorer?sslmode=disable", "database connection string")
 	addr = flag.String("addr", ":9998", "used to listen and serve http requests")
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,23 @@ go 1.18
 
 require (
 	github.com/IBM-Blockchain/fabric-operator v0.0.0-00010101000000-000000000000
+	github.com/go-logr/logr v1.2.2
 	github.com/go-pg/pg/v10 v10.11.0
 	github.com/gofiber/fiber/v2 v2.42.0
 	github.com/hyperledger/fabric-gateway v1.2.2
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.2.0
+	github.com/onsi/ginkgo/v2 v2.1.4
+	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
+	github.com/tektoncd/pipeline v0.33.0
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.28.1
+	k8s.io/api v0.22.5
 	k8s.io/apimachinery v0.22.5
 	k8s.io/apiserver v0.22.5
 	k8s.io/client-go v0.22.5
 	k8s.io/klog/v2 v2.90.1
+	sigs.k8s.io/controller-runtime v0.10.3
 )
 
 require (
@@ -44,7 +50,7 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-kit/log v0.1.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect
-	github.com/go-logr/logr v1.2.2 // indirect
+	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
@@ -91,7 +97,6 @@ require (
 	github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d // indirect
 	github.com/spf13/cobra v1.3.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/tektoncd/pipeline v0.33.0 // indirect
 	github.com/tinylib/msgp v1.1.6 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
@@ -134,7 +139,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.22.5 // indirect
 	k8s.io/apiextensions-apiserver v0.22.5 // indirect
 	k8s.io/component-base v0.22.5 // indirect
 	k8s.io/kube-openapi v0.0.0-20220114203427-a0453230fd26 // indirect
@@ -142,9 +146,13 @@ require (
 	knative.dev/pkg v0.0.0-20220131144930-f4b57aef0006 // indirect
 	mellium.im/sasl v0.3.1 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22 // indirect
-	sigs.k8s.io/controller-runtime v0.10.3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/IBM-Blockchain/fabric-operator => github.com/bestchains/fabric-operator v0.1.3-0.20230324052234-d879467a38d5
+replace (
+	github.com/IBM-Blockchain/fabric-operator => github.com/bestchains/fabric-operator v0.1.3-0.20230324052234-d879467a38d5
+	github.com/go-logr/logr => github.com/go-logr/logr v0.4.0
+	github.com/hyperledger/fabric-protos-go => github.com/Abirdcfly/fabric-protos-go v0.0.0-20230324110652-fee4e1b29726
+	k8s.io/klog/v2 => k8s.io/klog/v2 v2.9.0
+)

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ contrib.go.opencensus.io/exporter/prometheus v0.4.0/go.mod h1:o7cosnyfuPVK0tB8q0
 contrib.go.opencensus.io/exporter/stackdriver v0.13.4/go.mod h1:aXENhDJ1Y4lIg4EUaVTwzvYETVNZk10Pu26tevFKLUc=
 contrib.go.opencensus.io/exporter/zipkin v0.1.2/go.mod h1:mP5xM3rrgOjpn79MM8fZbj3gsxcuytSqtH0dxSWW1RE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/Abirdcfly/fabric-protos-go v0.0.0-20230324110652-fee4e1b29726 h1:q9rI3bESbHvT620BqMATQwRgyE56UbIPyJ92jOXy4EI=
+github.com/Abirdcfly/fabric-protos-go v0.0.0-20230324110652-fee4e1b29726/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/Antonboom/errname v0.1.5/go.mod h1:DugbBstvPFQbv/5uLcRRzfrNqKE9tVdVCqWCLp6Cifo=
 github.com/Antonboom/nilnil v0.1.0/go.mod h1:PhHLvRPSghY5Y7mX4TW+BHZQYo1A8flE5H20D3IPZBo=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -560,12 +562,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
-github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
-github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/zapr v0.4.0 h1:uc1uML3hRYL9/ZZPdgHS/n8Nzo+eaYL/Efxkkamf7OM=
 github.com/go-logr/zapr v0.4.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
@@ -875,9 +873,6 @@ github.com/hyperledger/fabric-config v0.0.5/go.mod h1:YpITBI/+ZayA3XWY5lF302K7PA
 github.com/hyperledger/fabric-gateway v1.2.2 h1:8Al1U2ciEtkiZ21701qbf9oOfd+4Y0inQUhTx1bDRMM=
 github.com/hyperledger/fabric-gateway v1.2.2/go.mod h1:Ziu7mVxlE2MCwmH0S8zK3WylwEMq1fVBgf+M8OJglQc=
 github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDWbQdbfz74n8kbCFsqc=
-github.com/hyperledger/fabric-protos-go v0.0.0-20200424173316-dd554ba3746e/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/hyperledger/fabric-protos-go v0.0.0-20211118165945-23d738fc3553 h1:E9f0v1q4EDfrE+0LdkxVtdYKAZ7PGCaj1bBx45R9yEQ=
-github.com/hyperledger/fabric-protos-go v0.0.0-20211118165945-23d738fc3553/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.2.0 h1:+J5f5uPzlgyfyeQ0nnqmuFYQvARGYG8SnZ8xODXlAsI=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.2.0/go.mod h1:smwq1q6eKByqQAp0SYdVvE1MvDoneF373j11XwWajgA=
 github.com/hyperledger/fabric-sdk-go v0.0.0-20221020141211-7af45cede6af h1:kxJp8MbPmku9oy8BXbydGcP68MW9kp45hz6mRKZ4N0c=
@@ -1147,6 +1142,7 @@ github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vv
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
+github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1159,6 +1155,7 @@ github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDs
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
+github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -2358,14 +2355,8 @@ k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAE
 k8s.io/gengo v0.0.0-20211129171323-c02415ce4185/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
-k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
-k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
-k8s.io/klog/v2 v2.4.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
+k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=
 k8s.io/klog/v2 v2.9.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
-k8s.io/klog/v2 v2.30.0/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
-k8s.io/klog/v2 v2.40.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
-k8s.io/klog/v2 v2.90.1 h1:m4bYOKall2MmOiRaR1J+We67Do7vm9KiQVlT96lnHUw=
-k8s.io/klog/v2 v2.90.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -107,7 +107,6 @@ func (fabclient *FabricClient) Channel(channel string) *client.Network {
 		return fabclient.gw.GetNetwork(channel)
 	}
 	return fabclient.primaryChannel
-
 }
 
 func (fabclient *FabricClient) Close() {

--- a/pkg/observer/base.go
+++ b/pkg/observer/base.go
@@ -20,35 +20,19 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/bestchains/bc-explorer/pkg/network"
-
 	"github.com/IBM-Blockchain/fabric-operator/pkg/generated/informers/externalversions"
+	"github.com/bestchains/bc-explorer/pkg/network"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/IBM-Blockchain/fabric-operator/pkg/generated/clientset/versioned"
 
-	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 )
 
-func Run(ctx context.Context, host, kubeConfigPath string) (err error) {
+func Run(ctx context.Context, config *rest.Config, host string) (err error) {
 	klog.V(5).Infof("observer start...")
-	var config *rest.Config
-	if kubeConfigPath == "" {
-		config, err = rest.InClusterConfig()
-		if err != nil {
-			return errors.Wrap(err, "create in-cluster client configuration error")
-		}
-	} else {
-		config, err = clientcmd.BuildConfigFromFlags("", kubeConfigPath)
-		if err != nil {
-			return errors.Wrap(err, "create out-of-cluster client configuration error")
-		}
-	}
-
 	vclient, err := versioned.NewForConfig(config)
 	if err != nil {
 		return err

--- a/pkg/observer/k8s.go
+++ b/pkg/observer/k8s.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	WrongTypeChannelErr = errors.New("wrong type of channel")
+	ErrWrongTypeChannel = errors.New("wrong type of channel")
 )
 
 type Watcher struct {
@@ -72,7 +72,7 @@ func (w *Watcher) ChannelCreate(obj interface{}) {
 	}
 	channel, ok := obj.(*v1beta1.Channel)
 	if !ok {
-		klog.ErrorS(WrongTypeChannelErr, "get wrong type of network", "obj", name)
+		klog.ErrorS(ErrWrongTypeChannel, "get wrong type of network", "obj", name)
 		return
 	}
 	if err := w.GetProfile(context.TODO(), channel); err != nil {
@@ -100,7 +100,7 @@ func (w *Watcher) ChannelDelete(obj interface{}) {
 	}
 	_, ok := obj.(*v1beta1.Channel)
 	if !ok {
-		klog.ErrorS(WrongTypeChannelErr, "get wrong type of channel", "obj", name)
+		klog.ErrorS(ErrWrongTypeChannel, "get wrong type of channel", "obj", name)
 		return
 	}
 	w.DeleteNames <- name

--- a/pkg/observer/profile.go
+++ b/pkg/observer/profile.go
@@ -18,7 +18,7 @@ package observer
 
 // copy from https://github.com/bestchains/fabric-operator/blob/d717b9e2df3319aaeaa5d804afec515ad8b948d3/pkg/connector/profile.go#L38-L138
 
-// Profile contasins all we need to connect with a blockchain network. Currently we use embeded pem by default
+// Profile contasins all we need to connect with a blockchain network. Currently we use embedded pem by default
 // +k8s:deepcopy-gen=true
 type Profile struct {
 	Version       string `yaml:"version,omitempty" json:"version,omitempty"`
@@ -95,7 +95,7 @@ type OrganizationInfo struct {
 	SignedCert      Pem `yaml:"signedCert,omitempty" json:"signedCert,omitempty"`
 }
 
-// User is the ca identity which has a private key(embeded pem) and signed certificate(embeded pem)
+// User is the ca identity which has a private key(embedded pem) and signed certificate(embedded pem)
 // +k8s:deepcopy-gen=true
 type User struct {
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`


### PR DESCRIPTION
see kubernetes-sigs/controller-runtime#1607 for log issue.

`github.com/hyperledger/fabric-protos-go => github.com/Abirdcfly/fabric-protos-go` because `fabric-operator` indirectly depends on `github.com/hyperledger/fabric-protos-go`, and we directly depends on `github.com/hyperledger/fabric-protos-go-apiv2`, they are different versions of proto files, which will **initialize multiple variables twice**, will cause `panic: proto: duplicate enum registered: common.MSPPrincipal_Classification`, My fork deleted the init function on the same commit.