### PR TITLE
fix: make binary fails on client due to sliceargs not found;add unit …

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,26 @@
+name: unit-tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  GO_VER: 1.18
+
+jobs:
+  make-checks:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VER }}
+      - name: run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ binary:
 clean:
 	rm -rf _output
 
+.PHONY: test
+test:
+	@hack/run-unit-tests.sh
+
 .PHONY: verify
 verify:
 	@hack/verify-copyright.sh

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/bestchains/bc-explorer/pkg/network"
+	"github.com/bestchains/bc-explorer/pkg/utils"
 
 	gwclient "github.com/hyperledger/fabric-gateway/pkg/client"
 
@@ -34,7 +35,7 @@ var (
 	profile  = flag.String("profile", "./network.json", "profile to connect with blockchain network")
 	contract = flag.String("contract", "samplecc", "contract name")
 	method   = flag.String("method", "PutValue", "contract method")
-	args     = new(sliceArgs)
+	args     = new(utils.SliceArgs)
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hyperledger/fabric-gateway v1.2.2
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.2.0
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.8.1
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.28.1
 	k8s.io/api v0.22.5
@@ -192,7 +193,6 @@ require (
 	github.com/spf13/viper v1.10.1 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/sylvia7788/contextcheck v1.0.4 // indirect
 	github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b // indirect
@@ -266,7 +266,7 @@ require (
 )
 
 replace (
-	github.com/IBM-Blockchain/fabric-operator => github.com/bestchains/fabric-operator v0.1.3-0.20230324052234-d879467a38d5
+	github.com/IBM-Blockchain/fabric-operator => github.com/bestchains/fabric-operator v0.1.3-0.20230404140140-4d4bef022ae9
 	github.com/go-logr/logr => github.com/go-logr/logr v0.4.0
 	github.com/hyperledger/fabric-protos-go => github.com/Abirdcfly/fabric-protos-go v0.0.0-20230324110652-fee4e1b29726
 	k8s.io/klog/v2 => k8s.io/klog/v2 v2.9.0

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bestchains/fabric-operator v0.1.3-0.20230324052234-d879467a38d5 h1:pANE/UOoCxyddo9eKzQo/VEn18+2Nnnbm7I5/th37sI=
-github.com/bestchains/fabric-operator v0.1.3-0.20230324052234-d879467a38d5/go.mod h1:Nq26XGiNjg2gxWzfOtKkaKtnk6k4yGs5+jLCOfqatRY=
+github.com/bestchains/fabric-operator v0.1.3-0.20230404140140-4d4bef022ae9 h1:JUg0MkcXKQREDi84vpHRjdk3ulb14KPHK1htNkKcA1c=
+github.com/bestchains/fabric-operator v0.1.3-0.20230404140140-4d4bef022ae9/go.mod h1:Nq26XGiNjg2gxWzfOtKkaKtnk6k4yGs5+jLCOfqatRY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=

--- a/hack/run-unit-tests.sh
+++ b/hack/run-unit-tests.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2023 The Bestchains Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "running unit tests"
+
+PKGS=$(go list ./...)
+
+if go test $PKGS -cover; then
+	echo "unit tests succeeded."
+else
+	echo "unit tests failed."
+	exit 1
+fi

--- a/pkg/utils/sliceargs.go
+++ b/pkg/utils/sliceargs.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 The Bestchains Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "strings"
+
+type SliceArgs []string
+
+func (s *SliceArgs) String() string {
+	return strings.Join(*s, ", ")
+}
+
+func (s *SliceArgs) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}

--- a/pkg/utils/sliceargs_test.go
+++ b/pkg/utils/sliceargs_test.go
@@ -14,17 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package utils
 
-import "strings"
+import (
+	"testing"
 
-type sliceArgs []string
+	"github.com/stretchr/testify/assert"
+)
 
-func (s *sliceArgs) String() string {
-	return strings.Join(*s, ", ")
-}
+func TestSliceArgs(t *testing.T) {
+	args := new(SliceArgs)
+	assert.Equal(t, "", args.String())
 
-func (s *sliceArgs) Set(value string) error {
-	*s = append(*s, value)
-	return nil
+	args.Set("arg1")
+	args.Set("arg2")
+	assert.Equal(t, "arg1, arg2", args.String())
 }

--- a/pkg/viewer/transaction.go
+++ b/pkg/viewer/transaction.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/viewer/viewer.go
+++ b/pkg/viewer/viewer.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
…tests

Changelog:
1. move sliceargs into pkg/utils so `WHAT=client make binary` can work
2. add unit test into makefile and github workflow